### PR TITLE
WIP: Hacky attempt at getting GCW Zero support working

### DIFF
--- a/projects/Makefile
+++ b/projects/Makefile
@@ -4,7 +4,7 @@
 .SUFFIXES:
 #---------------------------------------------------------------------------------
 
-PLATFORM:=  RASPI
+PLATFORM:=  GCWZERO
 
 include $(PWD)/Makefile.$(PLATFORM)
 

--- a/projects/Makefile.GCWZERO
+++ b/projects/Makefile.GCWZERO
@@ -1,0 +1,17 @@
+
+DEVKIT=/opt/gcw0-toolchain
+
+TOOLPATH=$(DEVKIT)/usr/bin
+PREFIX		:=	
+SDL_BASE = /opt/gcw0-toolchain/usr/bin/
+
+include $(PWD)/dingoo_rules
+
+CFLAGS	:=	`sdl-config --cflags` -O3 -D_DEBUG -Wall -DPLATFORM_$(PLATFORM) -I$(PWD)/../sources -D__LINUX_ALSA__  -DCPP_MEMORY
+
+CXXFLAGS:=	$(CFLAGS)
+
+EXTENSION:= dge
+
+LIBS	:=  -L/opt/gcw0-toolchain/usr/lib -lSDL -lpthread 
+LIBDIRS	:=	$(DEKVIT)/usr/lib

--- a/projects/gcwzero_rules
+++ b/projects/gcwzero_rules
@@ -1,0 +1,9 @@
+-include $(PWD)/base_rules
+
+#STRIP = mipsel-linux-strip
+STRIP = ls
+
+#---------------------------------------------------------------------------------
+%.dge: $(OFILES)
+	$(CXX) $(LDFLAGS) -o $@ $(OFILES) $(LIBS)
+	@$(STRIP) $@

--- a/sources/System/Console/Trace.cpp
+++ b/sources/System/Console/Trace.cpp
@@ -45,7 +45,7 @@ void Trace::VLog(const char* category,  const char *fmt, const va_list& args)
   
   char *ptr = buffer+strlen(buffer);
   
-  vsprintf(ptr,fmt,args ); 
+  //vsprintf(ptr,fmt,args ); 
   GetInstance()->AddLine(buffer) ;
   
 }


### PR DESCRIPTION
This is just a first hacky attempt at getting GCW Zero to compile.

I did the following:

On Xubuntu, I downloaded and installed the GCW Zero toolchain following all instructions on this page: http://www.gcw-zero.com/develop including adding `/opt/gcw0-toolchain/usr/bin` to my `$PATH`.

I also `sudo apt-get install sdl-1.2dev`.

I switch into `~/Projects/LittleGPTracker/projects`, and run `make`.

I get the following error:

```
rjungemann@artisanix-xubuntu:~/Projects/LittleGPTracker/projects$ make
Logger.cpp
mipsel-linux-g++ -MMD -MF /home/rjungemann/Projects/LittleGPTracker/projects/buildGCWZERO/Logger.d `sdl-config --cflags` -O3 -D_DEBUG -Wall -DPLATFORM_GCWZERO -I/home/rjungemann/Projects/LittleGPTracker/projects/../sources -D__LINUX_ALSA__  -DCPP_MEMORY -c /home/rjungemann/Projects/LittleGPTracker/projects/../sources/System/Console/Logger.cpp -o Logger.o
/bin/sh: 1: mipsel-linux-g++: not found
/home/rjungemann/Projects/LittleGPTracker/projects/base_rules:33: recipe for target 'Logger.o' failed
make[1]: *** [Logger.o] Error 127
Makefile:426: recipe for target 'buildGCWZERO' failed
make: *** [buildGCWZERO] Error 2
rjungemann@artisanix-xubuntu:~/Projects/LittleGPTracker/projects$ vim Makefile.GCWZERO 
rjungemann@artisanix-xubuntu:~/Projects/LittleGPTracker/projects$ make
Logger.cpp
gcw0-toolchain-g++ -MMD -MF /home/rjungemann/Projects/LittleGPTracker/projects/buildGCWZERO/Logger.d `sdl-config --cflags` -O3 -D_DEBUG -Wall -DPLATFORM_GCWZERO -I/home/rjungemann/Projects/LittleGPTracker/projects/../sources -D__LINUX_ALSA__  -DCPP_MEMORY -c /home/rjungemann/Projects/LittleGPTracker/projects/../sources/System/Console/Logger.cpp -o Logger.o
/bin/sh: 1: gcw0-toolchain-g++: not found
/home/rjungemann/Projects/LittleGPTracker/projects/base_rules:33: recipe for target 'Logger.o' failed
make[1]: *** [Logger.o] Error 127
Makefile:426: recipe for target 'buildGCWZERO' failed
make: *** [buildGCWZERO] Error 2
rjungemann@artisanix-xubuntu:~/Projects/LittleGPTracker/projects$ vim Makefile.GCWZERO 
rjungemann@artisanix-xubuntu:~/Projects/LittleGPTracker/projects$ make
Logger.cpp
g++ -MMD -MF /home/rjungemann/Projects/LittleGPTracker/projects/buildGCWZERO/Logger.d `sdl-config --cflags` -O3 -D_DEBUG -Wall -DPLATFORM_GCWZERO -I/home/rjungemann/Projects/LittleGPTracker/projects/../sources -D__LINUX_ALSA__  -DCPP_MEMORY -c /home/rjungemann/Projects/LittleGPTracker/projects/../sources/System/Console/Logger.cpp -o Logger.o
Trace.cpp
g++ -MMD -MF /home/rjungemann/Projects/LittleGPTracker/projects/buildGCWZERO/Trace.d `sdl-config --cflags` -O3 -D_DEBUG -Wall -DPLATFORM_GCWZERO -I/home/rjungemann/Projects/LittleGPTracker/projects/../sources -D__LINUX_ALSA__  -DCPP_MEMORY -c /home/rjungemann/Projects/LittleGPTracker/projects/../sources/System/Console/Trace.cpp -o Trace.o
/home/rjungemann/Projects/LittleGPTracker/projects/../sources/System/Console/Trace.cpp: In static member function ‘static void Trace::VLog(const char*, const char*, const __va_list_tag (&)[1])’:
/home/rjungemann/Projects/LittleGPTracker/projects/../sources/System/Console/Trace.cpp:48:25: error: invalid conversion from ‘const __va_list_tag*’ to ‘__va_list_tag*’ [-fpermissive]
   vsprintf(ptr,fmt,args ); 
                         ^
In file included from /usr/include/features.h:367:0,
                 from /usr/include/stdlib.h:24,
                 from /home/rjungemann/Projects/LittleGPTracker/projects/../sources/System/System/System.h:6,
                 from /home/rjungemann/Projects/LittleGPTracker/projects/../sources/System/Console/Trace.cpp:1:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:43:1: note:   initializing argument 3 of ‘int vsprintf(char*, const char*, __va_list_tag*)’
 __NTH (vsprintf (char *__restrict __s, const char *__restrict __fmt,
 ^
/home/rjungemann/Projects/LittleGPTracker/projects/base_rules:33: recipe for target 'Trace.o' failed
make[1]: *** [Trace.o] Error 1
Makefile:426: recipe for target 'buildGCWZERO' failed
make: *** [buildGCWZERO] Error 2
rjungemann@artisanix-xubuntu:~/Projects/LittleGPTracker/projects$ vim gcw0-toolchain
rjungemann@artisanix-xubuntu:~/Projects/LittleGPTracker/projects$ vim /home/rjungemann/Projects/LittleGPTracker/sources/System/Console/Trace.
rjungemann@artisanix-xubuntu:~/Projects/LittleGPTracker/projects$ vim /home/rjungemann/Projects/LittleGPTracker/sources/System/Console/Trace.h 
rjungemann@artisanix-xubuntu:~/Projects/LittleGPTracker/projects$ vim /home/rjungemann/Projects/LittleGPTracker/sources/System/Console/Trace.cpp
rjungemann@artisanix-xubuntu:~/Projects/LittleGPTracker/projects$ make
Trace.cpp
g++ -MMD -MF /home/rjungemann/Projects/LittleGPTracker/projects/buildGCWZERO/Trace.d `sdl-config --cflags` -O3 -D_DEBUG -Wall -DPLATFORM_GCWZERO -I/home/rjungemann/Projects/LittleGPTracker/projects/../sources -D__LINUX_ALSA__  -DCPP_MEMORY -c /home/rjungemann/Projects/LittleGPTracker/projects/../sources/System/Console/Trace.cpp -o Trace.o
/home/rjungemann/Projects/LittleGPTracker/projects/../sources/System/Console/Trace.cpp: In static member function ‘static void Trace::VLog(const char*, const char*, const __va_list_tag (&)[1])’:
/home/rjungemann/Projects/LittleGPTracker/projects/../sources/System/Console/Trace.cpp:46:9: warning: unused variable ‘ptr’ [-Wunused-variable]
   char *ptr = buffer+strlen(buffer);
         ^
Result.cpp
g++ -MMD -MF /home/rjungemann/Projects/LittleGPTracker/projects/buildGCWZERO/Result.d `sdl-config --cflags` -O3 -D_DEBUG -Wall -DPLATFORM_GCWZERO -I/home/rjungemann/Projects/LittleGPTracker/projects/../sources -D__LINUX_ALSA__  -DCPP_MEMORY -c /home/rjungemann/Projects/LittleGPTracker/projects/../sources/System/Errors/Result.cpp -o Result.o
In file included from /home/rjungemann/Projects/LittleGPTracker/projects/../sources/System/Errors/Result.cpp:1:0:
/home/rjungemann/Projects/LittleGPTracker/projects/../sources/System/Errors/Result.h: In constructor ‘Result::Result()’:
/home/rjungemann/Projects/LittleGPTracker/projects/../sources/System/Errors/Result.h:27:7: warning: ‘Result::success_’ will be initialized after [-Wreorder]
  bool success_ ;
       ^
/home/rjungemann/Projects/LittleGPTracker/projects/../sources/System/Errors/Result.h:26:14: warning:   ‘std::__cxx11::string Result::error_’ [-Wreorder]
  std::string error_ ;
              ^
/home/rjungemann/Projects/LittleGPTracker/projects/../sources/System/Errors/Result.cpp:6:1: warning:   when initialized here [-Wreorder]
 Result::Result()
 ^
In file included from /home/rjungemann/Projects/LittleGPTracker/projects/../sources/System/Errors/Result.cpp:1:0:
/home/rjungemann/Projects/LittleGPTracker/projects/../sources/System/Errors/Result.h: In constructor ‘Result::Result(const string&)’:
/home/rjungemann/Projects/LittleGPTracker/projects/../sources/System/Errors/Result.h:27:7: warning: ‘Result::success_’ will be initialized after [-Wreorder]
  bool success_ ;
       ^
/home/rjungemann/Projects/LittleGPTracker/projects/../sources/System/Errors/Result.h:26:14: warning:   ‘std::__cxx11::string Result::error_’ [-Wreorder]
  std::string error_ ;
              ^
/home/rjungemann/Projects/LittleGPTracker/projects/../sources/System/Errors/Result.cpp:12:1: warning:   when initialized here [-Wreorder]
 Result::Result(const std::string &error)
 ^
In file included from /home/rjungemann/Projects/LittleGPTracker/projects/../sources/System/Errors/Result.cpp:1:0:
/home/rjungemann/Projects/LittleGPTracker/projects/../sources/System/Errors/Result.h: In constructor ‘Result::Result(const ostringstream&)’:
/home/rjungemann/Projects/LittleGPTracker/projects/../sources/System/Errors/Result.h:27:7: warning: ‘Result::success_’ will be initialized after [-Wreorder]
  bool success_ ;
       ^
/home/rjungemann/Projects/LittleGPTracker/projects/../sources/System/Errors/Result.h:26:14: warning:   ‘std::__cxx11::string Result::error_’ [-Wreorder]
  std::string error_ ;
              ^
/home/rjungemann/Projects/LittleGPTracker/projects/../sources/System/Errors/Result.cpp:18:1: warning:   when initialized here [-Wreorder]
 Result::Result(const std::ostringstream &error)
 ^
In file included from /home/rjungemann/Projects/LittleGPTracker/projects/../sources/System/Errors/Result.cpp:1:0:
/home/rjungemann/Projects/LittleGPTracker/projects/../sources/System/Errors/Result.h: In constructor ‘Result::Result(Result&, const string&)’:
/home/rjungemann/Projects/LittleGPTracker/projects/../sources/System/Errors/Result.h:27:7: warning: ‘Result::success_’ will be initialized after [-Wreorder]
  bool success_ ;
       ^
/home/rjungemann/Projects/LittleGPTracker/projects/../sources/System/Errors/Result.h:26:14: warning:   ‘std::__cxx11::string Result::error_’ [-Wreorder]
  std::string error_ ;
              ^
/home/rjungemann/Projects/LittleGPTracker/projects/../sources/System/Errors/Result.cpp:24:1: warning:   when initialized here [-Wreorder]
 Result::Result(Result &cause,const std::string &error)
 ^
Status.cpp
g++ -MMD -MF /home/rjungemann/Projects/LittleGPTracker/projects/buildGCWZERO/Status.d `sdl-config --cflags` -O3 -D_DEBUG -Wall -DPLATFORM_GCWZERO -I/home/rjungemann/Projects/LittleGPTracker/projects/../sources -D__LINUX_ALSA__  -DCPP_MEMORY -c /home/rjungemann/Projects/LittleGPTracker/projects/../sources/System/io/Status.cpp -o Status.o
Config.cpp
g++ -MMD -MF /home/rjungemann/Projects/LittleGPTracker/projects/buildGCWZERO/Config.d `sdl-config --cflags` -O3 -D_DEBUG -Wall -DPLATFORM_GCWZERO -I/home/rjungemann/Projects/LittleGPTracker/projects/../sources -D__LINUX_ALSA__  -DCPP_MEMORY -c /home/rjungemann/Projects/LittleGPTracker/projects/../sources/Application/Model/Config.cpp -o Config.o
Timer.cpp
g++ -MMD -MF /home/rjungemann/Projects/LittleGPTracker/projects/buildGCWZERO/Timer.d `sdl-config --cflags` -O3 -D_DEBUG -Wall -DPLATFORM_GCWZERO -I/home/rjungemann/Projects/LittleGPTracker/projects/../sources -D__LINUX_ALSA__  -DCPP_MEMORY -c /home/rjungemann/Projects/LittleGPTracker/projects/../sources/System/Timer/Timer.cpp -o Timer.o
FileSystem.cpp
g++ -MMD -MF /home/rjungemann/Projects/LittleGPTracker/projects/buildGCWZERO/FileSystem.d `sdl-config --cflags` -O3 -D_DEBUG -Wall -DPLATFORM_GCWZERO -I/home/rjungemann/Projects/LittleGPTracker/projects/../sources -D__LINUX_ALSA__  -DCPP_MEMORY -c /home/rjungemann/Projects/LittleGPTracker/projects/../sources/System/FileSystem/FileSystem.cpp -o FileSystem.o
In file included from /home/rjungemann/Projects/LittleGPTracker/projects/../sources/System/FileSystem/FileSystem.cpp:1:0:
/home/rjungemann/Projects/LittleGPTracker/projects/../sources/System/FileSystem/FileSystem.h: In constructor ‘Path::Path()’:
/home/rjungemann/Projects/LittleGPTracker/projects/../sources/System/FileSystem/FileSystem.h:73:11: warning: ‘Path::type_’ will be initialized after [-Wreorder]
  FileType type_ ;
           ^
/home/rjungemann/Projects/LittleGPTracker/projects/../sources/System/FileSystem/FileSystem.h:72:7: warning:   ‘bool Path::gotType_’ [-Wreorder]
  bool gotType_ ;
       ^
/home/rjungemann/Projects/LittleGPTracker/projects/../sources/System/FileSystem/FileSystem.cpp:10:1: warning:   when initialized here [-Wreorder]
 Path::Path():type_(FT_UNKNOWN),gotType_(false) {
 ^
In file included from /home/rjungemann/Projects/LittleGPTracker/projects/../sources/System/FileSystem/FileSystem.cpp:1:0:
/home/rjungemann/Projects/LittleGPTracker/projects/../sources/System/FileSystem/FileSystem.h: In constructor ‘Path::Path(const char*)’:
/home/rjungemann/Projects/LittleGPTracker/projects/../sources/System/FileSystem/FileSystem.h:73:11: warning: ‘Path::type_’ will be initialized after [-Wreorder]
  FileType type_ ;
           ^
/home/rjungemann/Projects/LittleGPTracker/projects/../sources/System/FileSystem/FileSystem.h:72:7: warning:   ‘bool Path::gotType_’ [-Wreorder]
  bool gotType_ ;
       ^
/home/rjungemann/Projects/LittleGPTracker/projects/../sources/System/FileSystem/FileSystem.cpp:15:1: warning:   when initialized here [-Wreorder]
 Path::Path(const char *path):type_(FT_UNKNOWN),gotType_(false) {
 ^
In file included from /home/rjungemann/Projects/LittleGPTracker/projects/../sources/System/FileSystem/FileSystem.cpp:1:0:
/home/rjungemann/Projects/LittleGPTracker/projects/../sources/System/FileSystem/FileSystem.h: In constructor ‘Path::Path(const string&)’:
/home/rjungemann/Projects/LittleGPTracker/projects/../sources/System/FileSystem/FileSystem.h:73:11: warning: ‘Path::type_’ will be initialized after [-Wreorder]
  FileType type_ ;
           ^
/home/rjungemann/Projects/LittleGPTracker/projects/../sources/System/FileSystem/FileSystem.h:72:7: warning:   ‘bool Path::gotType_’ [-Wreorder]
  bool gotType_ ;
       ^
/home/rjungemann/Projects/LittleGPTracker/projects/../sources/System/FileSystem/FileSystem.cpp:20:1: warning:   when initialized here [-Wreorder]
 Path::Path(const std::string &path):type_(FT_UNKNOWN),gotType_(false) {
 ^
make[1]: *** No rule to make target 'SysMutex.o', needed by '/home/rjungemann/Projects/LittleGPTracker/projects/lgpt.dge'.  Stop.
Makefile:426: recipe for target 'buildGCWZERO' failed
make: *** [buildGCWZERO] Error 2
```