### PR TITLE
Set the initial directory to the current directory

### DIFF
--- a/sources/Adapters/DEB/System/DEBSystem.cpp
+++ b/sources/Adapters/DEB/System/DEBSystem.cpp
@@ -54,7 +54,7 @@ void DEBSystem::Boot(int argc,char **argv) {
 	}
 	Path::SetAlias("bin",dirname(buff)) ;
 
-	Path::SetAlias("root","bin:..") ;
+	Path::SetAlias("root",".") ;
 
 #ifdef _DEBUG
   Trace::GetInstance()->SetLogger(*(new StdOutLogger()));


### PR DESCRIPTION
Without this patch, the user has to navigate from the installation directory,
which (for example in NixOS) could entail loading big directory
listings, which make the program crash.

---

This is a patch we have to apply [in the NixOS package](https://github.com/NixOS/nixpkgs/pull/91766).
Hopefully this can be in upstream!